### PR TITLE
remove-section-styling

### DIFF
--- a/pages/kathmandu.html
+++ b/pages/kathmandu.html
@@ -43,7 +43,7 @@
         </nav>
     </header>
     <main>
-      <section class="hero-section flex-center" id="top">
+      <section class="hero-section flex-center section" id="top">
         <h1>Kathmandu Unveiled: Explore, Experience, Enjoy!</h1>
         <h2>
           Dive into the essence of Kathmandu – a city where ancient meets
@@ -52,7 +52,7 @@
         </h2>
         <a href="#slideshow">Learn more</a>
       </section>
-      <section class="slideshow" id="slideshow">
+      <section class="slideshow section" id="slideshow">
           <div class="slider">
             <figure class="slide">
               <img
@@ -126,7 +126,7 @@
             </figure>
           </div>
       </section>
-      <section class="details-section" id="swayambhunath">
+      <section class="details-section section" id="swayambhunath">
         <h2>Swayambhunath Temple</h2>
         <div class="details-container">
           <picture>
@@ -166,7 +166,7 @@
           </aside>
         </div>
       </section>
-      <section class="details-section" id="bhaktapur-durbar-square">
+      <section class="details-section section" id="bhaktapur-durbar-square">
         <h2>Bhaktapur Durbar Square</h2>
         <div class="details-container">
           <aside class="details-text-container">
@@ -210,7 +210,7 @@
           </picture>
         </div>
       </section>
-      <section class="details-section" id="narayanhiti-palace-museum">
+      <section class="details-section section" id="narayanhiti-palace-museum">
         <h2>Narayanhiti Palace Museum</h2>
         <div class="details-container">
           <picture>
@@ -251,7 +251,7 @@
           </aside>
         </div>
       </section>
-      <section class="details-section" id="pashupatinath-temple">
+      <section class="details-section section" id="pashupatinath-temple">
         <h2>Pashupatinath Temple</h2>
         <div class="details-container">
           <aside class="details-text-container">
@@ -292,7 +292,7 @@
           </picture>
         </div>
       </section>
-      <section class="details-section" id="kopan-monastry">
+      <section class="details-section section" id="kopan-monastry">
         <h2>Kopan Monastry</h2>
         <div class="details-container">
           <picture>

--- a/styles/home.css
+++ b/styles/home.css
@@ -331,6 +331,7 @@ footer nav{
 	.anchor-container a:first-child{
 		font-size: 1.6rem;
 	}
+	.anchor-container a:nth-child(5)
 
 	.hero-text-container{
 		margin-right: 2rem;

--- a/styles/kathmandu.css
+++ b/styles/kathmandu.css
@@ -37,7 +37,7 @@ html{
 	transition: 0.5s;
 	cursor: pointer;
 }
-section{
+.section{
     max-width: 100%;
     height: 100vh;
     padding: 2rem 0;
@@ -357,7 +357,7 @@ footer nav{
     .details-section h2{
         font-size: 3rem;
     }
-    section{
+    .section{
         min-height: 100vh;
         height: auto;
     }


### PR DESCRIPTION
## Changed section element styling to class styling

## This PR
> * [x]   Replace section element styling with class section

## Because
Loom extension creates a section at the end of the page that inherits the section stylings. To bypass that, created a class section and added it to each section to avoid styling the section element directly.