### PR TITLE
added quotes to kathmandu page to cover gap

### DIFF
--- a/pages/kathmandu.html
+++ b/pages/kathmandu.html
@@ -1,358 +1,373 @@
 <!DOCTYPE html>
 <html lang="en">
-  <head>
-    <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <meta
-      name="description"
-      content="Travel page about Kathmandu, reasons to visit kathmandu, Nepal."
-    />
-    <link rel="preconnect" href="https://fonts.googleapis.com" />
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-    <link
-      href="https://fonts.googleapis.com/css2?family=Roboto:ital,wght@0,100;0,300;0,400;0,500;0,700;0,900;1,100;1,300;1,400;1,500;1,700;1,900&display=swap"
-      rel="stylesheet"
-    />
-    <link rel="stylesheet" href="../styles/kathmandu.css" />
-    <link
-      rel="stylesheet"
-      href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css"
-      integrity="sha512-DTOQO9RWCH3ppGqcWaEA1BIZOC6xxalwEsw9c2QQeAIftl+Vegovlnee1c9QX4TctnWMn13TZye+giMm8e2LwA=="
-      crossorigin="anonymous"
-      referrerpolicy="no-referrer"
-    />
-    <link
-      rel="icon"
-      type="image/png"
-      sizes="16x16"
-      href="../images/favicon_io/favicon-16x16.png"
-    />
-    <title>TravelStorm:Kathmandu</title>
-  </head>
-  <body>
-    <header>
-        <picture class="logo-container">
-          <a  href="../index.html">TravelStorm</a>
-        </picture>
-        <nav class="anchor-container flex-center">
-          <a href="../index.html">Home</a>
-          <a href="../pages/brussels.html">Brussels</a>
-          <a href="../pages/kathmandu.html" class="current-page">Kathmandu</a>
-          <a href="../pages/newcastle.html">Newcastle</a>
-          <a href="../pages/telaviv.html">Tel-Aviv</a>
-        </nav>
-    </header>
-    <main>
-      <section class="hero-section flex-center section" id="top">
-        <h1>Kathmandu Unveiled: Explore, Experience, Enjoy!</h1>
-        <h2>
-          Dive into the essence of Kathmandu – a city where ancient meets
-          adventure. Immerse in culture, savor flavors, and embark on Himalayan
-          escapades. Your Kathmandu getaway starts now!
-        </h2>
-        <a href="#slideshow">Learn more</a>
-      </section>
-      <section class="slideshow section" id="slideshow">
-          <div class="slider">
-            <figure class="slide">
-              <img
-                src="../images/kathmandu/kathmandu_swayambhunath_temple.jpg"
-                alt="Swayambhunath Temple: Majestic stupa surrounded by prayer flags, an iconic symbol of spiritual serenity in Kathmandu."
-              >
-              <h3>Swayambhunath: The Enchanting Stupa of Kathmandu</h3>
-              <p>
-                Ascend to serenity at Swayambhunath, the iconic Monkey Temple.
-                Marvel at ancient wisdom, panoramic views, and the spiritual
-                energy that permeates this UNESCO World Heritage site. Immerse
-                yourself in a journey of enlightenment at the heart of
-                Kathmandu.
-              </p>
-              <a href="#swayambhunath">View details</a>
-            </figure>
-            <figure class="slide">
-              <img
-                src="../images/kathmandu/kathmandu_bhaktapur_durbar_square.jpg"
-                alt="Bhaktapur Durbar Square: Timeless architecture and vibrant heritage captured in the heart of Bhaktapur, Nepal."
-              >
-              <h3>Bhaktapur Durbar Square: Timeless Elegance in Nepal</h3>
-              <p>
-                Explore the heart of Bhaktapur's history at Durbar Square.
-                Admire ancient architecture, soak in local culture, and wander
-                through a living museum of Nepal's glorious past.
-              </p>
-              <a href="#bhaktapur-durbar-square">View details</a>
-            </figure>
-            <figure class="slide">
-              <img
-                src="../images/kathmandu/kathmandu_narayanhiti_palace_museum.jpg"
-                alt="Narayanhiti Palace Museum: Regal elegance preserved, offering a glimpse into Nepal's royal history and opulent past."
-              >
-              <h3>Narayanhiti Palace Museum: Royal Splendor Preserved</h3>
-              <p>
-                Discover the opulence and intrigue of Nepal's royal history at
-                Narayanhiti Palace Museum. Walk through halls where kings and
-                queens once roamed, and uncover the rich tapestry of the
-                nation's past, elegantly preserved within these historic walls.
-              </p>
-              <a href="#narayanhiti-palace-museum">View details</a>
-            </figure>
-            <figure class="slide">
-              <img
-                src="../images/kathmandu/kathmandu_pashupatinath_temple.jpg"
-                alt="Pashupatinath Temple: Sacred beauty along the Bagmati River, an iconic UNESCO site blending spirituality and ancient rituals."
-              >
-              <h3>Pashupatinath Temple: The Holy Temple</h3>
-              <p>
-                Immerse in divine tranquility at Pashupatinath Temple, where
-                spirituality meets the serenity of the Bagmati River. Explore
-                the essence of Nepal's religious heritage in this revered UNESCO
-                site.
-              </p>
-              <a href="#pashupatinath-temple">View details</a>
-            </figure>
-            <figure class="slide">
-              <img
-                src="../images/kathmandu/kathmandu_kopan_monastery.jpg"
-                alt="Kopan Monastery nestled in the hills, a tranquil retreat for spiritual seekers and meditation enthusiasts"
-              >
-              <h3>Kopan Monastery: Retreat into Spiritual Bliss</h3>
-              <p>
-                Nestled in the hills, Kopan Monastery beckons with its peaceful
-                ambiance and spiritual teachings. Discover serenity, meditation,
-                and Tibetan Buddhist wisdom in this haven overlooking Kathmandu
-                Valley.
-              </p>
-              <a href="#kopan-monastry">View details</a>
-            </figure>
-          </div>
-      </section>
-      <section class="details-section section" id="swayambhunath">
-        <h2>Swayambhunath Temple</h2>
-        <div class="details-container">
-          <picture>
-            <img
-            src="../images/kathmandu/kathmandu_swayambunath_temple_details.jpg"
-            alt="swayambunath temple the majestic stupa"
-            loading="lazy"
-            >
-          </picture>
-          <aside class="details-text-container">
-            <p>
-              Swayambhunath is a glorious ancient religious architecture,
-              located in the middle of Kathmandu city. It is center of faith of
-              both Buddhist and Hindus.
-            </p>
-            <dl>
-              <dt>
-                <i class="fa-solid fa-clock-rotate-left fa-2xl"></i>
-                <span>Duration:</span>
-              </dt>
-              <dd>3 - 4 hours</dd>
-              <dt>
-                <i class="fa-solid fa-location-dot fa-2xl"></i>
-                <span>Location:</span>
-              </dt>
-              <dd>Swoyambhu, Kathmandu, Nepal</dd>
-              <dt>
-                <i class="fa-regular fa-money-bill-1 fa-2xl"></i>
-                <span>Entrance Fee:</span>
-              </dt>
-              <dd>NPR 200</dd>
-              <dt>
-                <i class="fa-regular fa-clock fa-2xl"></i>
-                <span>Opening Hours:</span>
-              </dt>
-              <dd>24 hours</dd>
-            </dl>
-              <button>Book a Tour</button>
-            </aside>
-        </div>
-      </section>
-      <section class="details-section section" id="bhaktapur-durbar-square">
-        <h2>Bhaktapur Durbar Square</h2>
-        <div class="details-container">
-          <aside class="details-text-container">
-            <p>
-              The ancient city Bhaktapur lies on the Eastern part of Kathmandu
-              valley which is also known as Bhadgaon or Khwopa. The historical
-              monument on around signifies medieval age culture and tradition of
-              Nepal and this old city is inhabited by indigenous Newari people
-              in large group. you can visit to this place to experience Nepali
-              culture,tradition,religion from right way.we are here to support
-              you for your tours.
-            </p>
-            <dl>
-              <dt>
-                <i class="fa-solid fa-clock-rotate-left fa-2xl"></i>
-                <span>Duration:</span>
-              </dt>
-                <dd>5 - 6 hours</span>
-              <dt>
-                <i class="fa-solid fa-location-dot fa-2xl"></i>
-                <span>Location:</span>
-              </dt>
-                <dd>Durbar Square, Bhaktapur, Nepal</dd>
-              <dt>
-                <i class="fa-regular fa-money-bill-1 fa-2xl"></i>
-                <span>Entrance Fee:</span>
-              </dt>
-              <dd>NPR 1000</dd>
-              <dt>
-                <i class="fa-regular fa-clock fa-2xl"></i>
-                <span>Opening Hours:</span>
-              </dt>
-              <dd>9 am - 6 pm</dd>
-            </dl>
-            <button>Book a Tour</button>
-          </aside>
-          <picture>
-            <img
-            src="../images/kathmandu/kathmandu_bhaktapur_durbar_square_details.jpg"
-            alt="bhaktapur durbar square the palace of kings"
-            loading="lazy"
-            />
-          </picture>
-        </div>
-      </section>
-      <section class="details-section section" id="narayanhiti-palace-museum">
-        <h2>Narayanhiti Palace Museum</h2>
-        <div class="details-container">
-          <picture>
-            <img
-            src="../images/kathmandu/kathmandu_narayanhiti_palace_museum-details.jpg"
-            alt="narayanhiti royal palace museum the royal history of nepal"
-            loading="lazy"
-            >
-          </picture>
-          <aside class="details-text-container">
-            <p>
-              Narayanhiti Royal Palace Museum in Kathmandu unveils Nepal's regal
-              history through ornate halls and curated exhibits of royal
-              artifacts. Explore opulent living quarters, ceremonial spaces, and
-              a collection of historical treasures, offering a glimpse into the country's royal heritage.
-            </p>
-            <dl>
-              <dt>
-                <i class="fa-solid fa-clock-rotate-left fa-2xl"></i>
-                <span>Duration:</span>
-              </dt>
-              <dd>3 hours</dd>
-              <dt>
-                <i class="fa-solid fa-location-dot fa-2xl"></i>
-                <span>Location:</span>
-              </dt>
-              <dd>Narayanhiti Path, Kathmandu, Nepal</dd>
-              <dt>
-                <i class="fa-regular fa-money-bill-1 fa-2xl"></i>
-                <span>Entrance Fee:</span>
-              </dt>
-              <dd>NPR 1000</dd>
-              <dt>
-                <i class="fa-regular fa-clock fa-2xl"></i>
-                <span>Opening Hours:</span>
-              </dt>
-              <dd>10:30 am - 3:30 pm</dd>
-            </dl>
-            <button>Book a Tour</button>
-          </aside>
-        </div>
-      </section>
-      <section class="details-section section" id="pashupatinath-temple">
-        <h2>Pashupatinath Temple</h2>
-        <div class="details-container">
-          <aside class="details-text-container">
-            <p>
-              Pashupatinath Temple, nestled along the Bagmati River, is a sacred
-              sanctuary in Kathmandu. A UNESCO World Heritage site, it blends
-              spirituality and ancient rituals, offering a serene space for
-              reflection amidst the cultural richness of Nepal.
-            </p>
-            <dl>
-              <dt>
-                <i class="fa-solid fa-clock-rotate-left fa-2xl"></i>
-                <span>Duration:</span>
-              </dt>
-              <dd>2 hours</dd>
-              <dt>
-                <i class="fa-solid fa-location-dot fa-2xl"></i>
-                <span>Location:</span>
-              </dt>
-              <dd>Pashupatinath, Kathmandu, Nepal</dd>
-              <dt>
-                <i class="fa-regular fa-money-bill-1 fa-2xl"></i>
-                <span>Entrance Fee:</span>
-              </dt>
-              <dd>NPR 1000</dd>
-              <dt>
-                <i class="fa-regular fa-clock fa-2xl"></i>
-                <span>Opening Hours:</span>
-              </dt>
-              <dd>4 am - 9 pm</dd>
-              </dl>
-              <button>Book a Tour</button>
-            </aside>
-          <picture>
-            <img
-            src="../images/kathmandu/kathmandu_pashupatinath_temple-details.jpg"
-            alt="the holy temple of pashupatinath"
-            loading="lazy"
-            >
-          </picture>
-        </div>
-      </section>
-      <section class="details-section section" id="kopan-monastry">
-        <h2>Kopan Monastry</h2>
-        <div class="details-container">
-          <picture>
-            <img
-            src="../images/kathmandu/kathmandu_kopan_monastery_details.jpg"
-            alt="Kopan Monastery: Tranquil Tibetan retreat"
-            loading="lazy"
-            >
-          </picture>
-          <aside class="details-text-container">
-            <p>
-              Kopan Monastery, nestled in serene surroundings, is a tranquil
-              Tibetan retreat near Kathmandu. Embrace the peaceful ambiance,
-              engage in meditation, and immerse yourself in Tibetan Buddhist
-              wisdom at this spiritual haven.
-            </p>
-            <dl>
-              <dt>
-                <i class="fa-solid fa-clock-rotate-left fa-2xl"></i>
-                <span>Duration:</span>
-              </dt>
-              <dd>2 - 3 hours</dd>
-              <dt>
-                <i class="fa-solid fa-location-dot fa-2xl"></i>
-                <span>Location:</span>
-              </dt>
-              <dd>Budhanilkantha, Kathmandu, Nepal</span>
-              <dt>
-                <i class="fa-regular fa-money-bill-1 fa-2xl"></i>
-                <span>Entrance Fee:</span>
-              </dt>
-              <dd>Free</dd>
-              <dt>
-                <i class="fa-regular fa-clock fa-2xl"></i>
-                <span>Opening Hours:</span>
-              </dt>
-              <dd>10 am - 4 pm</dd>
-            </dl>
-            <button>Book a Tour</button>
-          </aside>
-        </div>
-      </section>
-    </main>
-    <footer class="flex-center flex-column">
-      <p>2024 &copy; All rights reserved to TravelStorm Inc.</p>
-      <nav class="flex-center">
-          <a href="#"><i class="icon hover fa-regular fa-envelope"></i></a>
-          <a href="#"><i class="icon hover fa-brands fa-facebook"></i></a>
-          <a href="#"><i class="icon hover fa-brands fa-instagram"></i></a>
-          <a href="#"><i class="icon hover fa-brands fa-twitter"></i></a>
-          <a href="#"><i class="icon hover fa-brands fa-linkedin"></i></a>
-        </nav>
-    </footer>
-  </body>
+	<head>
+		<meta charset="UTF-8" />
+		<meta name="viewport" content="width=device-width, initial-scale=1.0" >
+		<meta name="description" content="Travel page about Kathmandu, reasons to visit kathmandu, Nepal." >
+		<link rel="preconnect" href="https://fonts.googleapis.com" >
+		<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin >
+		<link
+			href="https://fonts.googleapis.com/css2?family=Roboto:ital,wght@0,100;0,300;0,400;0,500;0,700;0,900;1,100;1,300;1,400;1,500;1,700;1,900&display=swap"
+			rel="stylesheet">
+		<link rel="stylesheet" href="../styles/kathmandu.css">
+		<link
+			rel="stylesheet"
+			href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css"
+			integrity="sha512-DTOQO9RWCH3ppGqcWaEA1BIZOC6xxalwEsw9c2QQeAIftl+Vegovlnee1c9QX4TctnWMn13TZye+giMm8e2LwA=="
+			crossorigin="anonymous"
+			referrerpolicy="no-referrer">
+		<link rel="icon" type="image/png" sizes="16x16" href="../images/favicon_io/favicon-16x16.png">
+		<title>TravelStorm:Kathmandu</title>
+	</head>
+	<body>
+		<header>
+			<picture class="logo-container">
+				<a href="../index.html">TravelStorm</a>
+			</picture>
+			<nav class="anchor-container flex-center">
+				<a href="../index.html">Home</a>
+				<a href="../pages/brussels.html">Brussels</a>
+				<a href="../pages/kathmandu.html" class="current-page">Kathmandu</a>
+				<a href="../pages/newcastle.html">Newcastle</a>
+				<a href="../pages/telaviv.html">Tel-Aviv</a>
+			</nav>
+		</header>
+		<main>
+			<section class="hero-section flex-center section" id="top">
+				<h1>Kathmandu Unveiled: Explore, Experience, Enjoy!</h1>
+				<h2>
+					Dive into the essence of Kathmandu – a city where ancient meets adventure. Immerse in culture, savor flavors,
+					and embark on Himalayan escapades. Your Kathmandu getaway starts now!
+				</h2>
+				<a href="#slideshow">Learn more</a>
+			</section>
+			<section class="slideshow section" id="slideshow">
+				<div class="slider">
+					<figure class="slide">
+						<img
+							src="../images/kathmandu/kathmandu_swayambhunath_temple.jpg"
+							alt="Swayambhunath Temple: Majestic stupa surrounded by prayer flags, an iconic symbol of spiritual serenity in Kathmandu.">
+						<h3>Swayambhunath: The Enchanting Stupa of Kathmandu</h3>
+						<p>
+							Ascend to serenity at Swayambhunath, the iconic Monkey Temple. Marvel at ancient wisdom, panoramic views,
+							and the spiritual energy that permeates this UNESCO World Heritage site. Immerse yourself in a journey of
+							enlightenment at the heart of Kathmandu.
+						</p>
+						<a href="#swayambhunath">View details</a>
+					</figure>
+					<figure class="slide">
+						<img
+							src="../images/kathmandu/kathmandu_bhaktapur_durbar_square.jpg"
+							alt="Bhaktapur Durbar Square: Timeless architecture and vibrant heritage captured in the heart of Bhaktapur, Nepal.">
+						<h3>Bhaktapur Durbar Square: Timeless Elegance in Nepal</h3>
+						<p>
+							Explore the heart of Bhaktapur's history at Durbar Square. Admire ancient architecture, soak in local
+							culture, and wander through a living museum of Nepal's glorious past.
+						</p>
+						<a href="#bhaktapur-durbar-square">View details</a>
+					</figure>
+					<figure class="slide">
+						<img
+							src="../images/kathmandu/kathmandu_narayanhiti_palace_museum.jpg"
+							alt="Narayanhiti Palace Museum: Regal elegance preserved, offering a glimpse into Nepal's royal history and opulent past.">
+						<h3>Narayanhiti Palace Museum: Royal Splendor Preserved</h3>
+						<p>
+							Discover the opulence and intrigue of Nepal's royal history at Narayanhiti Palace Museum. Walk through
+							halls where kings and queens once roamed, and uncover the rich tapestry of the nation's past, elegantly
+							preserved within these historic walls.
+						</p>
+						<a href="#narayanhiti-palace-museum">View details</a>
+					</figure>
+					<figure class="slide">
+						<img
+							src="../images/kathmandu/kathmandu_pashupatinath_temple.jpg"
+							alt="Pashupatinath Temple: Sacred beauty along the Bagmati River, an iconic UNESCO site blending spirituality and ancient rituals.">
+						<h3>Pashupatinath Temple: The Holy Temple</h3>
+						<p>
+							Immerse in divine tranquility at Pashupatinath Temple, where spirituality meets the serenity of the
+							Bagmati River. Explore the essence of Nepal's religious heritage in this revered UNESCO site.
+						</p>
+						<a href="#pashupatinath-temple">View details</a>
+					</figure>
+					<figure class="slide">
+						<img
+							src="../images/kathmandu/kathmandu_kopan_monastery.jpg"
+							alt="Kopan Monastery nestled in the hills, a tranquil retreat for spiritual seekers and meditation enthusiasts">
+						<h3>Kopan Monastery: Retreat into Spiritual Bliss</h3>
+						<p>
+							Nestled in the hills, Kopan Monastery beckons with its peaceful ambiance and spiritual teachings. Discover
+							serenity, meditation, and Tibetan Buddhist wisdom in this haven overlooking Kathmandu Valley.
+						</p>
+						<a href="#kopan-monastry">View details</a>
+					</figure>
+				</div>
+			</section>
+			<section class="details-section section" id="swayambhunath">
+				<h2>Swayambhunath Temple</h2>
+				<div class="details-container">
+					<picture>
+						<img
+							src="../images/kathmandu/kathmandu_swayambunath_temple_details.jpg"
+							alt="swayambunath temple the majestic stupa"
+							loading="lazy">
+					</picture>
+					<aside class="details-text-container">
+						<p>
+							Swayambhunath is a glorious ancient religious architecture, located in the middle of Kathmandu city. It is
+							center of faith of both Buddhist and Hindus.
+						</p>
+						<dl>
+							<dt>
+								<i class="fa-solid fa-clock-rotate-left fa-2xl"></i>
+								<span>Duration:</span>
+							</dt>
+							<dd>3 - 4 hours</dd>
+							<dt>
+								<i class="fa-solid fa-location-dot fa-2xl"></i>
+								<span>Location:</span>
+							</dt>
+							<dd>Swoyambhu, Kathmandu, Nepal</dd>
+							<dt>
+								<i class="fa-regular fa-money-bill-1 fa-2xl"></i>
+								<span>Entrance Fee:</span>
+							</dt>
+							<dd>NPR 200</dd>
+							<dt>
+								<i class="fa-regular fa-clock fa-2xl"></i>
+								<span>Opening Hours:</span>
+							</dt>
+							<dd>24 hours</dd>
+						</dl>
+						<blockquote>
+							<q>
+								"Visiting Swayambhunath Temple was absolutely amazing. The tranquility in the air and the breathtaking views of Kathmandu Valley made it a truly special experience. It's a must-visit that leaves you with a sense of peace and awe."
+							</q>
+							<cite>
+								— Outi Kettunen
+							</cite>
+							<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"><path d="M9.983 3v7.391c0 5.704-3.731 9.57-8.983 10.609l-.995-2.151c2.432-.917 3.995-3.638 3.995-5.849h-4v-10h9.983zm14.017 0v7.391c0 5.704-3.748 9.571-9 10.609l-.996-2.151c2.433-.917 3.996-3.638 3.996-5.849h-3.983v-10h9.983z" fill="currentColor"/>
+							</svg>
+						</blockquote>
+						<button>Book a Tour</button>
+					</aside>
+				</div>
+			</section>
+			<section class="details-section section" id="bhaktapur-durbar-square">
+				<h2>Bhaktapur Durbar Square</h2>
+				<div class="details-container">
+					<aside class="details-text-container">
+						<p>
+							The ancient city Bhaktapur lies on the Eastern part of Kathmandu valley which is also known as Bhadgaon or
+							Khwopa. The historical monument on around signifies medieval age culture and tradition of Nepal and this
+							old city is inhabited by indigenous Newari people in large group. you can visit to this place to
+							experience Nepali culture,tradition,religion from right way.we are here to support you for your tours.
+						</p>
+						<dl>
+							<dt>
+								<i class="fa-solid fa-clock-rotate-left fa-2xl"></i>
+								<span>Duration:</span>
+							</dt>
+							<dd>5 - 6 hours</dd>
+							<dt>
+								<i class="fa-solid fa-location-dot fa-2xl"></i>
+								<span>Location:</span>
+							</dt>
+							<dd>Durbar Square, Bhaktapur, Nepal</dd>
+							<dt>
+								<i class="fa-regular fa-money-bill-1 fa-2xl"></i>
+								<span>Entrance Fee:</span>
+							</dt>
+							<dd>NPR 1000</dd>
+							<dt>
+								<i class="fa-regular fa-clock fa-2xl"></i>
+								<span>Opening Hours:</span>
+							</dt>
+							<dd>9 am - 6 pm</dd>
+						</dl>
+						<blockquote>
+							<q>
+								"Roaming around Bhaktapur Durbar Square was pure magic. The ancient architecture and lively vibe transported me to another era. It's like unlocking a cultural treasure chest. Bhaktapur, you stole my heart!"
+							</q>
+							<cite>
+								— Will
+							</cite>
+							<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"><path d="M9.983 3v7.391c0 5.704-3.731 9.57-8.983 10.609l-.995-2.151c2.432-.917 3.995-3.638 3.995-5.849h-4v-10h9.983zm14.017 0v7.391c0 5.704-3.748 9.571-9 10.609l-.996-2.151c2.433-.917 3.996-3.638 3.996-5.849h-3.983v-10h9.983z" fill="currentColor"/>
+							</svg>
+						</blockquote>
+						<button>Book a Tour</button>
+					</aside>
+					<picture>
+						<img
+							src="../images/kathmandu/kathmandu_bhaktapur_durbar_square_details.jpg"
+							alt="bhaktapur durbar square the palace of kings"
+							loading="lazy">
+					</picture>
+				</div>
+			</section>
+			<section class="details-section section" id="narayanhiti-palace-museum">
+				<h2>Narayanhiti Palace Museum</h2>
+				<div class="details-container">
+					<picture>
+						<img
+							src="../images/kathmandu/kathmandu_narayanhiti_palace_museum-details.jpg"
+							alt="narayanhiti royal palace museum the royal history of nepal"
+							loading="lazy">
+					</picture>
+					<aside class="details-text-container">
+						<p>
+							Narayanhiti Royal Palace Museum in Kathmandu unveils Nepal's regal history through ornate halls and
+							curated exhibits of royal artifacts. Explore opulent living quarters, ceremonial spaces, and a collection
+							of historical treasures, offering a glimpse into the country's royal heritage.
+						</p>
+						<dl>
+							<dt>
+								<i class="fa-solid fa-clock-rotate-left fa-2xl"></i>
+								<span>Duration:</span>
+							</dt>
+							<dd>3 hours</dd>
+							<dt>
+								<i class="fa-solid fa-location-dot fa-2xl"></i>
+								<span>Location:</span>
+							</dt>
+							<dd>Narayanhiti Path, Kathmandu, Nepal</dd>
+							<dt>
+								<i class="fa-regular fa-money-bill-1 fa-2xl"></i>
+								<span>Entrance Fee:</span>
+							</dt>
+							<dd>NPR 1000</dd>
+							<dt>
+								<i class="fa-regular fa-clock fa-2xl"></i>
+								<span>Opening Hours:</span>
+							</dt>
+							<dd>10:30 am - 3:30 pm</dd>
+						</dl>
+						<blockquote>
+							<q>
+								"It was truly captivating to delve into the rich tapestry of Nepal's royal history. Exploring the majestic halls and artifacts offered a glimpse into a bygone era, leaving me in awe of the grandeur and heritage preserved within Narayanhiti Palace Museum."
+							</q>
+							<cite>
+								— Jason Parker
+							</cite>
+							<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"><path d="M9.983 3v7.391c0 5.704-3.731 9.57-8.983 10.609l-.995-2.151c2.432-.917 3.995-3.638 3.995-5.849h-4v-10h9.983zm14.017 0v7.391c0 5.704-3.748 9.571-9 10.609l-.996-2.151c2.433-.917 3.996-3.638 3.996-5.849h-3.983v-10h9.983z" fill="currentColor"/>
+							</svg>
+						</blockquote>
+						<button>Book a Tour</button>
+					</aside>
+				</div>
+			</section>
+			<section class="details-section section" id="pashupatinath-temple">
+				<h2>Pashupatinath Temple</h2>
+				<div class="details-container">
+					<aside class="details-text-container">
+						<p>
+							Pashupatinath Temple, nestled along the Bagmati River, is a sacred sanctuary in Kathmandu. A UNESCO World
+							Heritage site, it blends spirituality and ancient rituals, offering a serene space for reflection amidst
+							the cultural richness of Nepal.
+						</p>
+						<dl>
+							<dt>
+								<i class="fa-solid fa-clock-rotate-left fa-2xl"></i>
+								<span>Duration:</span>
+							</dt>
+							<dd>2 hours</dd>
+							<dt>
+								<i class="fa-solid fa-location-dot fa-2xl"></i>
+								<span>Location:</span>
+							</dt>
+							<dd>Pashupatinath, Kathmandu, Nepal</dd>
+							<dt>
+								<i class="fa-regular fa-money-bill-1 fa-2xl"></i>
+								<span>Entrance Fee:</span>
+							</dt>
+							<dd>NPR 1000</dd>
+							<dt>
+								<i class="fa-regular fa-clock fa-2xl"></i>
+								<span>Opening Hours:</span>
+							</dt>
+							<dd>4 am - 9 pm</dd>
+						</dl>
+						<blockquote>
+							<q>
+								"Exploring Pashupatinath Temple was serene and spiritual. The ancient rituals and sacred atmosphere made it a truly special place. Pashupatinath, a timeless sanctuary, left me in awe."
+							</q>
+							<cite>
+								— Sarah
+							</cite>
+							<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"><path d="M9.983 3v7.391c0 5.704-3.731 9.57-8.983 10.609l-.995-2.151c2.432-.917 3.995-3.638 3.995-5.849h-4v-10h9.983zm14.017 0v7.391c0 5.704-3.748 9.571-9 10.609l-.996-2.151c2.433-.917 3.996-3.638 3.996-5.849h-3.983v-10h9.983z" fill="currentColor"/>
+							</svg>
+						</blockquote>
+						<button>Book a Tour</button>
+					</aside>
+					<picture>
+						<img
+							src="../images/kathmandu/kathmandu_pashupatinath_temple-details.jpg"
+							alt="the holy temple of pashupatinath"
+							loading="lazy">
+					</picture>
+				</div>
+			</section>
+			<section class="details-section section" id="kopan-monastry">
+				<h2>Kopan Monastry</h2>
+				<div class="details-container">
+					<picture>
+						<img
+							src="../images/kathmandu/kathmandu_kopan_monastery_details.jpg"
+							alt="Kopan Monastery: Tranquil Tibetan retreat"
+							loading="lazy"
+						/>
+					</picture>
+					<aside class="details-text-container">
+						<p>
+							Kopan Monastery, nestled in serene surroundings, is a tranquil Tibetan retreat near Kathmandu. Embrace the
+							peaceful ambiance, engage in meditation, and immerse yourself in Tibetan Buddhist wisdom at this spiritual
+							haven.
+						</p>
+						<dl>
+							<dt>
+								<i class="fa-solid fa-clock-rotate-left fa-2xl"></i>
+								<span>Duration:</span>
+							</dt>
+							<dd>2 - 3 hours</dd>
+							<dt>
+								<i class="fa-solid fa-location-dot fa-2xl"></i>
+								<span>Location:</span>
+							</dt>
+							<span>Budhanilkantha, Kathmandu, Nepal</span>
+							<dt>
+								<i class="fa-regular fa-money-bill-1 fa-2xl"></i>
+								<span>Entrance Fee:</span>
+							</dt>
+							<dd>Free</dd>
+							<dt>
+								<i class="fa-regular fa-clock fa-2xl"></i>
+								<span>Opening Hours:</span>
+							</dt>
+							<dd>10 am - 4 pm</dd>
+						</dl>
+						<blockquote>
+							<q>
+								"Wandering through Kopan Monastery was a peaceful escape. The serene surroundings and the gentle hum of prayers offered a tranquil retreat. Discovering the teachings and warmth of the community made my visit truly enriching. Kopan, a hidden gem for inner peace."
+							</q>
+							<cite>
+								— Jisoo Park
+							</cite>
+							<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"><path d="M9.983 3v7.391c0 5.704-3.731 9.57-8.983 10.609l-.995-2.151c2.432-.917 3.995-3.638 3.995-5.849h-4v-10h9.983zm14.017 0v7.391c0 5.704-3.748 9.571-9 10.609l-.996-2.151c2.433-.917 3.996-3.638 3.996-5.849h-3.983v-10h9.983z" fill="currentColor"/>
+							</svg>
+						</blockquote>
+						<button>Book a Tour</button>
+					</aside>
+				</div>
+			</section>
+		</main>
+		<footer class="flex-center flex-column">
+			<p>2024 &copy; All rights reserved to TravelStorm Inc.</p>
+			<nav class="flex-center">
+				<a href="#"><i class="icon hover fa-regular fa-envelope"></i></a>
+				<a href="#"><i class="icon hover fa-brands fa-facebook"></i></a>
+				<a href="#"><i class="icon hover fa-brands fa-instagram"></i></a>
+				<a href="#"><i class="icon hover fa-brands fa-twitter"></i></a>
+				<a href="#"><i class="icon hover fa-brands fa-linkedin"></i></a>
+			</nav>
+		</footer>
+	</body>
 </html>

--- a/styles/kathmandu.css
+++ b/styles/kathmandu.css
@@ -312,12 +312,11 @@ i {
 	display: flex;
 	flex-wrap: wrap;
 }
-.details-text-container dt{
+.details-text-container dt {
 	width: 50%;
 	padding: 1rem 0;
 	display: flex;
 	align-items: center;
-	
 }
 .details-text-container dt span {
 	font-size: 1.8rem;
@@ -336,6 +335,47 @@ i {
 	cursor: pointer;
 	width: 50%;
 	font-size: 2.4rem;
+}
+blockquote{
+	margin-top: auto;
+	align-self: center;
+	display: flex;
+	flex-direction: column;
+	position: relative;
+	font-size: 2rem;
+	padding: 2rem 0;
+}
+blockquote::before{
+	content: "";
+	position: absolute;
+	left: 0;
+	top: 0;
+	width: 100%;
+	height: 2px;
+	background: rgb(175,143,78);
+}
+blockquote::after{
+	content: "";
+	position: absolute;
+	left: 0;
+	bottom: 0;
+	width: 100%;
+	height: 2px;
+	background: rgb(175,143,78);
+}
+blockquote cite{
+	text-align: center;
+}
+blockquote svg{
+	position: absolute;
+	top: 0;
+	left: 45%;
+	translate: 0 -50%;
+	color: rgb(175,143,78);
+	background-color: #e5e7eb;
+	z-index: 10;
+	width: 5rem;
+	text-align: center;
 }
 /*************************************************************/
 /**************************** footer *************************/
@@ -458,5 +498,8 @@ footer nav {
 	}
 	.details-text-container dl dt i {
 		font-size: 1.4rem;
+	}
+	blockquote{
+		font-size: 1.5rem;
 	}
 }


### PR DESCRIPTION
## Utilizes the long gap on the details section

## This PR
> * [x]   Replaced the gap in the details section with a blockquote.

## Because
The gap on the details section was too big.